### PR TITLE
Allow messageClass to be an interface

### DIFF
--- a/DependencyInjection/MessengerPass.php
+++ b/DependencyInjection/MessengerPass.php
@@ -114,10 +114,10 @@ class MessengerPass implements CompilerPassInterface
                         $method = $method[0];
                     }
 
-                    if (!\class_exists($messageClass)) {
+                    if (!\class_exists($messageClass) && !\interface_exists($messageClass)) {
                         $messageClassLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : $r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method);
 
-                        throw new RuntimeException(sprintf('Invalid handler service "%s": message class "%s" %s does not exist.', $serviceId, $messageClass, $messageClassLocation));
+                        throw new RuntimeException(sprintf('Invalid handler service "%s": message class or interface "%s" %s does not exist.', $serviceId, $messageClass, $messageClassLocation));
                     }
 
                     if (!$r->hasMethod($method)) {


### PR DESCRIPTION
It makes it easier to implement an event bus. Our __invoke method uses the Event interface instead of the class itself.