### PR TITLE
Allow exchange type headers binding

### DIFF
--- a/Transport/AmqpExt/Connection.php
+++ b/Transport/AmqpExt/Connection.php
@@ -160,7 +160,7 @@ class Connection
         $this->exchange()->declareExchange();
 
         $this->queue()->declareQueue();
-        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null);
+        $this->queue()->bind($this->exchange()->getName(), $this->queueConfiguration['routing_key'] ?? null, $this->queueConfiguration['arguments'] ?? null);
     }
 
     public function channel(): \AMQPChannel


### PR DESCRIPTION
Allows the use of headers exchange to deliver messages by defining the headers to bind.
When binding a exchange of type headers to a queue, adding the arguments allows you to define the message routing correctly.