### PR TITLE
publish message  with custom queue options : flags | attributes

### DIFF
--- a/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -233,6 +233,25 @@ class ConnectionTest extends TestCase
         $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key&auto-setup=false', [], true, $factory);
         $connection->publish('body');
     }
+
+    public function testPublishWithQueueOptions()
+    {
+        $factory = new TestAmqpFactory(
+            $amqpConnection = $this->getMockBuilder(\AMQPConnection::class)->disableOriginalConstructor()->getMock(),
+            $amqpChannel = $this->getMockBuilder(\AMQPChannel::class)->disableOriginalConstructor()->getMock(),
+            $amqpQueue = $this->getMockBuilder(\AMQPQueue::class)->disableOriginalConstructor()->getMock(),
+            $amqpExchange = $this->getMockBuilder(\AMQPExchange::class)->disableOriginalConstructor()->getMock()
+        );
+        $headers = [
+            'type' => '*',
+        ];
+        $amqpExchange->expects($this->once())->method('publish')
+            ->with('body', null, 1, ['delivery_mode' => 2, 'headers' => $headers]);
+
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[attributes][delivery_mode]=2&queue[flags]=1', [], true, $factory);
+        $connection->publish('body', $headers);
+    }
+
 }
 
 class TestAmqpFactory extends AmqpFactory

--- a/Transport/AmqpExt/Connection.php
+++ b/Transport/AmqpExt/Connection.php
@@ -133,7 +133,10 @@ class Connection
             $this->setup();
         }
 
-        $this->exchange()->publish($body, $this->queueConfiguration['routing_key'] ?? null, AMQP_NOPARAM, ['headers' => $headers]);
+        $flags = $this->queueConfiguration['flags'] ?? AMQP_NOPARAM;
+        $attributes = array_merge_recursive($this->queueConfiguration['attributes'] ?? [], ['headers' => $headers]);
+
+        $this->exchange()->publish($body, $this->queueConfiguration['routing_key'] ?? null, $flags, $attributes);
     }
 
     /**


### PR DESCRIPTION
option for publish persistent message: 
`amqp://localhost/%2f/messages?queue[attributes][delivery_mode]=2&queue[flags]=1`
or
`                options:
                    queue:
                        name: '%env(MESSENGER_QUEUE)%'
                        routing_key: '%env(MESSENGER_ROUTING_KEY)%'
                        attributes:
                            delivery_mode: 2
                        flags: 1
`