### PR TITLE
[Messenger] Allow to configure the db index on Redis transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ CHANGELOG
 4.2.0
 -----
 
- * Added `HandleTrait` leveraging a message bus instance to return a single 
+ * Added `HandleTrait` leveraging a message bus instance to return a single
    synchronous message handling result
  * Added `HandledStamp` & `SentStamp` stamps
  * All the changes below are BC BREAKS

--- a/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/Tests/Transport/RedisExt/ConnectionTest.php
@@ -113,6 +113,15 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('redis://password@localhost/queue', [], $redis);
     }
 
+    public function testDbIndex()
+    {
+        $redis = new \Redis();
+
+        Connection::fromDsn('redis://password@localhost/queue?dbindex=2', [], $redis);
+
+        $this->assertSame(2, $redis->getDbNum());
+    }
+
     public function testFirstGetPendingMessagesThenNewMessages()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
Allow redis to use dbIndex as it's already implemented in 4.4 and 5