### PR TITLE
Missing command description for the SetupTransportsCommand

### DIFF
--- a/Command/SetupTransportsCommand.php
+++ b/Command/SetupTransportsCommand.php
@@ -41,6 +41,7 @@ class SetupTransportsCommand extends Command
     {
         $this
             ->addArgument('transport', InputArgument::OPTIONAL, 'Name of the transport to setup', null)
+            ->setDescription('Prepares the needed infrastructure for the transport')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command setups the transports:
 


### PR DESCRIPTION
making the `bin/console` command to show no description when listing commands available

![image](https://user-images.githubusercontent.com/351553/81716131-51a5de80-9479-11ea-896c-2a927e424480.png)
