### PR TITLE
chore: add redeliveredAt in RedeliveryStamp construct

### DIFF
--- a/Stamp/RedeliveryStamp.php
+++ b/Stamp/RedeliveryStamp.php
@@ -24,12 +24,12 @@ final class RedeliveryStamp implements StampInterface
     private $exceptionMessage;
     private $flattenException;
 
-    public function __construct(int $retryCount, string $exceptionMessage = null, FlattenException $flattenException = null)
+    public function __construct(int $retryCount, string $exceptionMessage = null, FlattenException $flattenException = null, \DateTimeTimmutable $redeliveredAt = new \DateTimeImmutable())
     {
         $this->retryCount = $retryCount;
         $this->exceptionMessage = $exceptionMessage;
         $this->flattenException = $flattenException;
-        $this->redeliveredAt = new \DateTimeImmutable();
+        $this->redeliveredAt = $redeliveredAt;
     }
 
     public static function getRetryCountFromEnvelope(Envelope $envelope): int


### PR DESCRIPTION
this would allows one to correctly unserialise a RedeliveryStamp with a custom serializer not using the php serialize function