### PR TITLE
Take in consideration max_retries setting when you throw a RecoverableMessageHandlingException

### DIFF
--- a/EventListener/SendFailedMessageForRetryListener.php
+++ b/EventListener/SendFailedMessageForRetryListener.php
@@ -135,7 +135,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
     private function shouldRetry(\Throwable $e, Envelope $envelope, RetryStrategyInterface $retryStrategy): bool
     {
-        if ($e instanceof RecoverableExceptionInterface) {
+        if ($e instanceof RecoverableExceptionInterface && $retryStrategy->isRetryable($envelope, $e) ) {
             return true;
         }
 
@@ -144,7 +144,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
         if ($e instanceof HandlerFailedException) {
             $shouldNotRetry = true;
             foreach ($e->getNestedExceptions() as $nestedException) {
-                if ($nestedException instanceof RecoverableExceptionInterface) {
+                if ($nestedException instanceof RecoverableExceptionInterface && $retryStrategy->isRetryable($envelope, $e) ) {
                     return true;
                 }
 


### PR DESCRIPTION
Hi all
Right now a message will be retried infinitely if you throw a Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException ignoring the max_retries setting in configuration file.

With this modification, that setting will not be ignored and will be taked in consideration.