### PR TITLE
[Messenger] Allow retries to be logged as warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Add the `LogRetryAsWarningInterface` for exceptions to log retries as warnings instead of errors allowing the same behaviour as RecoverableExceptionInterface while still using the retry strategy
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
  * Add support for resetting container services after each messenger message.
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.

--- a/EventListener/SendFailedMessageForRetryListener.php
+++ b/EventListener/SendFailedMessageForRetryListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageRetriedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogRetryAsWarningInterface;
 use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
@@ -72,11 +73,11 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
             if (null !== $this->logger) {
                 $logLevel = LogLevel::ERROR;
-                if ($throwable instanceof RecoverableExceptionInterface) {
+                if ($throwable instanceof LogRetryAsWarningInterface) {
                     $logLevel = LogLevel::WARNING;
                 } elseif ($throwable instanceof HandlerFailedException) {
                     foreach ($throwable->getNestedExceptions() as $nestedException) {
-                        if ($nestedException instanceof RecoverableExceptionInterface) {
+                        if ($nestedException instanceof LogRetryAsWarningInterface) {
                             $logLevel = LogLevel::WARNING;
                             break;
                         }

--- a/Exception/LogRetryAsWarningInterface.php
+++ b/Exception/LogRetryAsWarningInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * Marker interface for exceptions to indicate a retry should be logged as warning instead of error.
+ *
+ * @author Joris Steyn <j.steyn@hoffelijk.nl>
+ */
+interface LogRetryAsWarningInterface
+{
+}

--- a/Exception/RecoverableExceptionInterface.php
+++ b/Exception/RecoverableExceptionInterface.php
@@ -19,6 +19,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-interface RecoverableExceptionInterface extends \Throwable
+interface RecoverableExceptionInterface extends LogRetryAsWarningInterface, \Throwable
 {
 }


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Related to problem described in comments of #15
| License       | MIT
| Doc PR        | pending
```

This PR introduces a marker interface for exceptions to allow retries to be logged as warnings instead of the default error severity.

This behaviour is already implemented for recoverable exceptions, but those are retried ad infinitum regardless of the retry strategy. With the new marker interface, it's possible to log exceptions as warnings while still using the retry strategy.

The RecoverableExceptionInterface now extends this interface to achieve the existing behaviour using the new more flexible approach.