### PR TITLE
update dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/deprecation-contracts": "^2.1|^3",
         "symfony/doctrine-messenger": "^5.1|^6.0",
         "symfony/polyfill-php80": "^1.16",
+        "symfony/notifier": "^5.1|^6.0",
         "symfony/redis-messenger": "^5.1|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
potentially fixing the required class
Invalid Messenger routing configuration: class or interface `Symfony\Component\Notifier\Message\ChatMessage` not found.