### PR TITLE
Add ext-pcntl to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-pcntl": "*",
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^6.3"
     },


### PR DESCRIPTION
Since ConsumeMessagesCommand.php uses SIGTERM and SIGINT, ext-pcntl must be available on system